### PR TITLE
Add teacher workspace route scaffolding

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "root": true,
+  "extends": ["next/core-web-vitals", "next/typescript"],
+  "rules": {
+    "@next/next/no-html-link-for-pages": "off"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.husky/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# chops-buddy
+# Chops Buddy
+
+A Next.js + Tailwind CSS project for building the Chops Buddy saxophone teaching platform. The MVP focuses on teacher scheduling, scale assignments, and guided practice summaries powered by Supabase.
+
+## Getting Started
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Run the development server:
+   ```bash
+   npm run dev
+   ```
+3. Open [http://localhost:3000](http://localhost:3000) to view the marketing landing page. Visit `/teacher/dashboard` for the teacher workspace prototype and `/docs/design` for the full product design document.
+
+## Documentation
+- [MVP Design Document](docs/design.md)
+
+## Tooling
+- TypeScript + App Router Next.js
+- Tailwind CSS for styling
+- ESLint & Prettier with Tailwind plugin
+- Husky + lint-staged (run `npm run prepare` after installing dependencies)
+
+## Project Roadmap
+Refer to the design document for detailed personas, page flows, and rollout plan. Upcoming milestones include Supabase integration, studio management features, and the guided practice tuner experience.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,152 @@
+# Chops Buddy MVP Design Document
+
+## 1. Product Overview
+Chops Buddy is a web-based platform that helps saxophone teachers manage students, assignments, and practice summaries while guiding students through structured practice sessions. The MVP targets saxophone instruction only and is built on a Next.js frontend with Supabase for authentication, data storage, and serverless APIs.
+
+## 2. Goals & Non-Goals
+### Goals
+- Allow teachers to manually add/manage students.
+- Capture teacher availability and track scheduled lessons.
+- Enable teachers to assign scale-based homework.
+- Generate guided practice sessions that walk students through assigned scales with tuner support.
+- Record practice duration and aggregate metrics without storing raw audio.
+- Allow students to send follow-up questions on assignments.
+
+### Non-Goals (Future Considerations)
+- Automatic student self-registration or guardian roles.
+- Third-party calendar integration (Google/Apple).
+- Full-length piece assignments (defer due to copyright).
+- Advanced analytics beyond total practice time (e.g., intonation scoring) in MVP.
+- Audio recording storage.
+- Comprehensive mobile apps (focus on mobile-friendly web with optional PWA wrapper).
+
+## 3. Personas & Primary User Journeys
+### Teacher (primary MVP persona)
+- Create account, set profile, add students.
+- Define recurring availability and view schedule.
+- Record lesson notes, assign scale homework.
+- Review student practice summaries and respond to questions.
+
+### Student
+- Log in, review assigned scales.
+- Launch guided practice session for each assignment.
+- Track practice time, mark completion steps, ask questions.
+
+## 4. Core Flows
+1. **Teacher Onboarding**
+   - Auth with Supabase, fill profile (instrument specialization, studio info).
+   - Create student records manually (name, contact, proficiency, instrument type).
+2. **Availability & Scheduling**
+   - Teacher sets weekly availability slots (time ranges, weekdays).
+   - Teachers book lessons with students or mark availability for manual scheduling.
+3. **Assignment Management**
+   - Teacher selects student, chooses scale assignment template (key, tempo target).
+   - Optionally add notes, due date, and practice time goal.
+4. **Guided Practice**
+   - Student selects assignment → sees session outline (warm-up, scale reps).
+   - Start session: tuner UI validates notes via Web Audio API, practice timer runs.
+   - Student marks attempts complete, notes struggles/questions.
+5. **Review & Feedback**
+   - Practice sessions summarize minutes practiced, attempts completed, student comments.
+   - Teacher dashboard highlights recent activity and outstanding questions.
+
+## 5. Information Architecture & Data Model (Supabase)
+| Table | Key Fields | Notes |
+|-------|------------|-------|
+| `profiles` | `id`, `role` (`teacher`/`student`), name, instrument, timezone | Extends Supabase auth users. |
+| `students` | `id`, `teacher_id`, `profile_id`, proficiency, notes | Many-to-one with teachers. |
+| `availability_slots` | `id`, `teacher_id`, `weekday`, `start_time`, `end_time`, recurrence metadata | Supports recurring weekly slots. |
+| `lessons` | `id`, `teacher_id`, `student_id`, `scheduled_at`, `duration`, `status`, `notes` | Connects to availability. |
+| `assignments` | `id`, `teacher_id`, `student_id`, `scale_key`, `octave_range`, `tempo_goal`, `due_date`, `notes`, `status` | Scales only in MVP. |
+| `practice_sessions` | `id`, `assignment_id`, `student_id`, `started_at`, `ended_at`, `duration_minutes`, `completion_status` | Derived metrics only. |
+| `practice_steps` | `id`, `practice_session_id`, `step_type` (warmup, repetition), `metadata` (JSON for tempo targets etc.), `status` | Guides session flow. |
+| `practice_metrics` | `practice_session_id`, `metric_type` (time_spent), `value` | Extensible for future metrics. |
+| `questions` | `id`, `practice_session_id`, `student_id`, `teacher_id`, `content`, `status`, `response` | Facilitates Q&A. |
+
+Row Level Security ensures teachers view only their students’ data and students only see their own records.
+
+## 6. System Architecture
+- **Frontend**: Next.js App Router with TypeScript; React Query/SWR for data fetching; Tailwind or Chakra for UI; PWA configuration for mobile-friendly tuner access.
+- **Backend**: Supabase Database + Auth; Supabase Edge Functions for business logic (e.g., assignment creation, summarizing practice sessions).
+- **Audio Processing**: Client-side Web Audio API with pitch detection (e.g., YIN/autocorrelation) implemented in a dedicated hook/library. Device permission prompts, fallbacks for unsupported browsers, guidance for mobile Safari/Chrome.
+- **State Management**: Minimal global state via React Context (auth profile) and server state via React Query.
+- **CI/CD & Maintenance**: GitHub Actions for linting (ESLint), type-checking (TypeScript `tsc --noEmit`), and future unit tests. Prettier formatting enforced via lint-staged & Husky. Documentation stored in `/docs`.
+
+## 7. Page Map & Primary UI Elements
+
+### 7.1 Teacher Experience
+| Page | Key Sections | Primary Buttons / Controls |
+|------|--------------|----------------------------|
+| **Auth Pages** (Sign Up / Login) | Supabase Auth UI, CTA to request student invite | `Create Account`, `Log In`, `Forgot Password` |
+| **Teacher Onboarding Wizard** | Profile setup (photo, timezone), studio details | `Save & Continue`, `Skip for now` |
+| **Dashboard** | Summary cards (active students, upcoming lessons, practice minutes), recent questions | `Add Student`, `Schedule Lesson`, `Create Assignment`, `Respond` (to questions) |
+| **Students List** | Search/filter by name, status | `Add Student`, `View Profile` |
+| **Student Detail** | Profile info, lesson history, assignments list, practice log | `Edit Student`, `Add Assignment`, `Message Student` |
+| **Availability Management** | Weekly calendar view, list of slots | `Add Availability`, `Edit`, `Delete`, `Copy Week` |
+| **Lesson Scheduler** | Calendar interface, slot picker, lesson form | `Schedule`, `Reschedule`, `Cancel Lesson` |
+| **Assignment Composer** | Scale selector, parameters (key, tempo, octave, repetitions), due date | `Create Assignment`, `Save Draft`, `Assign Later` |
+| **Assignment Detail** | Overview, linked practice sessions, metrics | `Mark Complete`, `Archive`, `Duplicate` |
+| **Practice Summary** | Table of sessions, filters (date range) | `Export CSV` (future), `View Session` |
+| **Question Inbox** | Threads from students | `Reply`, `Mark Resolved`, `Archive` |
+| **Settings** | Profile, notifications, tuner settings, PWA install prompt | `Update Profile`, `Manage Notifications`, `Install App` (PWA prompt) |
+
+### 7.2 Student Experience
+| Page | Key Sections | Primary Buttons / Controls |
+|------|--------------|----------------------------|
+| **Auth Pages** | Supabase magic link or password login | `Log In`, `Request Access` |
+| **Student Dashboard** | Assigned scales, upcoming lesson, streak/prompt | `Start Practice`, `View Assignment`, `Ask Question` |
+| **Assignment Detail** | Scale instructions, teacher notes, due date, time goal | `Start Guided Session`, `Mark Complete`, `Ask Question` |
+| **Guided Practice Session** | Step-by-step interface: tuner readout, metronome, practice timer, progress tracker | `Start Timer`, `Record Attempt`, `Complete Step`, `Pause`, `Finish Session`, `Report Issue` |
+| **Practice Log** | Timeline/list of sessions | `View Details`, `Filter by Assignment` |
+| **Questions & Messages** | Threaded conversation with teacher | `New Message`, `Attach Recording` (future), `Mark Resolved` |
+| **Profile & Settings** | Instrument, goals, device setup tips for tuner | `Update Profile`, `Configure Audio`, `Install App` |
+
+### 7.3 Shared / Global Components
+- **Navigation Bar**: Role-based items (Dashboard, Students/Assignments, Practice, Messages, Settings).
+- **Notifications Drawer**: Alerts for new assignments, upcoming lessons, responses.
+- **Help & Support Modal**: Documentation links, contact form.
+- **Mobile Considerations**: Bottom navigation for small screens, large touch targets for tuner controls.
+
+## 8. Guided Practice Feature Design
+1. **Session Initialization**: Student selects assignment → fetch scale metadata and predetermined practice steps (e.g., warm-up breath, scale ascending, descending).
+2. **Audio Calibration**: Prompt to allow microphone, display input-level meter, allow selection of instrument transposition (alto vs tenor).
+3. **Pitch Detection Module**:
+   - Real-time frequency analysis with tolerance thresholds per note.
+   - Visual feedback: color-coded intonation indicator, note name display.
+   - Support for alternate fingerings (future).
+4. **Step Tracking & Timer**:
+   - Each step includes recommended repetitions/time.
+   - Timer records total active practice minutes; idle detection warns if no audio detected.
+5. **Session Completion**:
+   - Summary modal with total time, steps completed, notes field.
+   - Option to send question to teacher.
+6. **Data Storage**:
+   - Write session record (start/end, duration).
+   - Aggregate per-assignment metrics, update teacher dashboard.
+
+## 9. Questions & Messaging
+- Inline chat linked to practice sessions for context.
+- Email notifications (via Supabase functions/SMTP) optional for new messages.
+
+## 10. Maintenance & Quality
+- **Documentation**: `/docs` directory housing this design doc, API specs, setup instructions.
+- **Testing Strategy**: Start with unit tests for utility functions, integration tests for critical flows (auth, assignment creation) using Playwright later.
+- **Code Quality**: ESLint + Prettier, strict TypeScript, commit hooks.
+- **Observability**: Log important events (practice session creation, assignments) to Supabase logs; plan future integration with analytics (e.g., PostHog).
+- **Accessibility & UX**: ARIA-friendly controls, keyboard navigation, color contrast compliance, accessible tuner feedback.
+- **Security & Privacy**: Supabase RLS policies, audit logging for user actions, secure microphone permissions, privacy policy covering audio processing without storage.
+
+## 11. Rollout Plan
+1. Implement Supabase schema and seed with sample data.
+2. Build teacher onboarding and student management UI.
+3. Develop assignment workflows and guided practice player.
+4. Integrate basic practice metrics dashboards.
+5. Conduct alpha testing with personal studio; gather feedback.
+6. Iterate on tuner accuracy and UI polish; prepare for beta release.
+
+## 12. Future Enhancements
+- Gamification (streaks, badges).
+- Intonation scoring, rhythm analysis.
+- Broader repertoire and exercise library.
+- Mobile-native apps if demand requires.
+- Multi-instrument support and content marketplace.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,10 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    typedRoutes: true,
+  },
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "chops-buddy",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "prepare": "husky install"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@supabase/supabase-js": "2.43.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.30",
+    "@types/react": "18.2.21",
+    "@types/react-dom": "18.2.7",
+    "autoprefixer": "10.4.16",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.5",
+    "husky": "9.0.11",
+    "lint-staged": "15.2.0",
+    "postcss": "8.4.35",
+    "prettier": "3.2.5",
+    "tailwindcss": "3.4.3",
+    "typescript": "5.4.5",
+    "prettier-plugin-tailwindcss": "0.5.11"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx}": [
+      "eslint --fix"
+    ],
+    "*.{ts,tsx,js,jsx,md,css,json}": [
+      "prettier --write"
+    ]
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -1,0 +1,11 @@
+/** @type {import("prettier").Config} */
+const config = {
+  semi: true,
+  singleQuote: false,
+  trailingComma: "all",
+  tabWidth: 2,
+  printWidth: 100,
+  plugins: ["prettier-plugin-tailwindcss"],
+};
+
+export default config;

--- a/src/app/(teacher)/teacher/assignments/page.tsx
+++ b/src/app/(teacher)/teacher/assignments/page.tsx
@@ -1,0 +1,107 @@
+import { PageHeader } from "@/components/page-header";
+
+const assignments = [
+  {
+    title: "Concert G Major scale",
+    student: "Alex Rivera",
+    due: "Due in 3 days",
+    status: "In progress",
+  },
+  {
+    title: "Chromatic warmup - 2 octaves",
+    student: "Maya Chen",
+    due: "Due in 5 days",
+    status: "Not started",
+  },
+  {
+    title: "Long-tone breath builder",
+    student: "Jordan Smith",
+    due: "Due tomorrow",
+    status: "Completed",
+  },
+];
+
+const templates = [
+  {
+    name: "Major scale",
+    description: "Select key, octave range, tempo goal, and tuner tolerance.",
+  },
+  {
+    name: "Chromatic drill",
+    description: "Customize start note, range, and subdivisions.",
+  },
+  {
+    name: "Long tone",
+    description: "Define sustain length, dynamics, and rest intervals.",
+  },
+];
+
+export default function AssignmentsPage() {
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title="Assignments"
+        description="Assign scales and drills, then monitor student progress through guided sessions."
+        actions={
+          <button
+            type="button"
+            className="rounded-xl bg-brand-dark px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-brand"
+          >
+            Create assignment
+          </button>
+        }
+      />
+
+      <section className="space-y-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <h2 className="text-lg font-semibold text-slate-900">Active assignments</h2>
+          <div className="flex flex-wrap gap-2">
+            <button className="rounded-xl border border-brand-dark px-3 py-2 text-sm text-brand-dark transition hover:bg-brand-light" type="button">
+              Filter by student
+            </button>
+            <button className="rounded-xl border border-brand-dark px-3 py-2 text-sm text-brand-dark transition hover:bg-brand-light" type="button">
+              Sort by due date
+            </button>
+          </div>
+        </div>
+        <div className="grid gap-4">
+          {assignments.map((assignment) => (
+            <article key={assignment.title} className="flex flex-col gap-2 rounded-2xl border border-slate-100 bg-slate-50 p-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h3 className="text-base font-semibold text-slate-900">{assignment.title}</h3>
+                <p className="text-sm text-slate-600">{assignment.student}</p>
+              </div>
+              <div className="flex flex-col items-start gap-2 text-sm text-slate-600 md:flex-row md:items-center">
+                <span>{assignment.due}</span>
+                <span className="rounded-full bg-white px-3 py-1 text-xs font-semibold uppercase tracking-wide text-brand-dark shadow-sm">
+                  {assignment.status}
+                </span>
+                <button className="rounded-xl bg-brand-dark px-3 py-2 text-sm font-medium text-white transition hover:bg-brand" type="button">
+                  View details
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section className="rounded-3xl border border-dashed border-brand-dark/40 bg-brand-light/40 p-6">
+        <h2 className="text-lg font-semibold text-brand-dark">Assignment templates</h2>
+        <p className="mt-2 text-sm text-brand-dark/80">
+          Templates help standardize guided practice steps. Customize them as you learn what motivates each student.
+        </p>
+        <div className="mt-4 grid gap-4 md:grid-cols-3">
+          {templates.map((template) => (
+            <article key={template.name} className="space-y-2 rounded-2xl bg-white p-4 shadow-sm">
+              <h3 className="text-base font-semibold text-slate-900">{template.name}</h3>
+              <p className="text-sm text-slate-600">{template.description}</p>
+              <button className="inline-flex items-center justify-center rounded-xl border border-brand-dark px-3 py-2 text-sm font-medium text-brand-dark transition hover:bg-brand-light" type="button">
+                Customize template
+              </button>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(teacher)/teacher/dashboard/page.tsx
+++ b/src/app/(teacher)/teacher/dashboard/page.tsx
@@ -1,0 +1,72 @@
+import { PageHeader } from "@/components/page-header";
+
+const focusAreas = [
+  {
+    title: "This week",
+    highlights: ["3 lessons scheduled", "2 assignments due", "1 student question awaiting reply"],
+  },
+  {
+    title: "Studio health",
+    highlights: ["Average practice time: 28 min", "New scale focus: Concert G Major", "Reminder: update spring recital info"],
+  },
+];
+
+const quickActions = [
+  {
+    label: "Add student",
+    description: "Create a profile, set skill level, and add notes from intake calls.",
+  },
+  {
+    label: "Schedule lesson",
+    description: "Pick an availability slot and attach a lesson goal for the week.",
+  },
+  {
+    label: "Log lesson notes",
+    description: "Capture takeaways while they are fresh to personalize assignments.",
+  },
+];
+
+export default function DashboardPage() {
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title="Teacher dashboard"
+        description="Track your studio at a glance and jump into the next high-impact task."
+      />
+
+      <section className="grid gap-6 md:grid-cols-2">
+        {focusAreas.map((item) => (
+          <article key={item.title} className="space-y-3 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+            <h2 className="text-lg font-semibold text-slate-900">{item.title}</h2>
+            <ul className="space-y-2 text-sm text-slate-600">
+              {item.highlights.map((highlight) => (
+                <li key={highlight} className="flex items-start gap-2">
+                  <span className="mt-1 inline-flex h-2 w-2 rounded-full bg-brand-dark" aria-hidden />
+                  <span>{highlight}</span>
+                </li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </section>
+
+      <section className="space-y-4 rounded-3xl border border-dashed border-brand-dark/40 bg-brand-light/40 p-6">
+        <h2 className="text-lg font-semibold text-brand-dark">Quick actions</h2>
+        <div className="grid gap-4 md:grid-cols-3">
+          {quickActions.map((action) => (
+            <div key={action.label} className="space-y-2 rounded-2xl bg-white p-4 shadow-sm">
+              <h3 className="text-base font-semibold text-slate-900">{action.label}</h3>
+              <p className="text-sm text-slate-600">{action.description}</p>
+              <button
+                type="button"
+                className="inline-flex w-full items-center justify-center rounded-xl bg-brand-dark px-3 py-2 text-sm font-medium text-white transition hover:bg-brand"
+              >
+                Plan this next
+              </button>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(teacher)/teacher/layout.tsx
+++ b/src/app/(teacher)/teacher/layout.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from "react";
+
+import { AppShell } from "@/components/app-shell";
+import type { AppNavItem } from "@/components/app-shell";
+
+const teacherNav: AppNavItem[] = [
+  {
+    href: "/teacher/dashboard",
+    label: "Dashboard",
+    description: "Studio snapshots and upcoming lessons",
+  },
+  {
+    href: "/teacher/students",
+    label: "Students",
+    description: "Roster, lesson notes, and individual plans",
+  },
+  {
+    href: "/teacher/assignments",
+    label: "Assignments",
+    description: "Create scale plans and monitor progress",
+  },
+  {
+    href: "/teacher/practice",
+    label: "Practice log",
+    description: "Guided session summaries and metrics",
+  },
+  {
+    href: "/teacher/questions",
+    label: "Questions",
+    description: "Respond to student follow-ups",
+  },
+  {
+    href: "/teacher/settings",
+    label: "Settings",
+    description: "Studio profile and notifications",
+  },
+];
+
+type TeacherLayoutProps = {
+  children: ReactNode;
+};
+
+export default function TeacherLayout({ children }: TeacherLayoutProps) {
+  return <AppShell navItems={teacherNav}>{children}</AppShell>;
+}

--- a/src/app/(teacher)/teacher/page.tsx
+++ b/src/app/(teacher)/teacher/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function TeacherIndexPage() {
+  redirect("/teacher/dashboard");
+}

--- a/src/app/(teacher)/teacher/practice/page.tsx
+++ b/src/app/(teacher)/teacher/practice/page.tsx
@@ -1,0 +1,100 @@
+import { PageHeader } from "@/components/page-header";
+
+const sessions = [
+  {
+    student: "Alex Rivera",
+    assignment: "Concert G Major scale",
+    duration: "18 min",
+    completedAt: "Yesterday",
+  },
+  {
+    student: "Maya Chen",
+    assignment: "Chromatic warmup",
+    duration: "12 min",
+    completedAt: "2 days ago",
+  },
+  {
+    student: "Jordan Smith",
+    assignment: "Long-tone breath builder",
+    duration: "20 min",
+    completedAt: "3 days ago",
+  },
+];
+
+const practiceInsights = [
+  {
+    label: "Average minutes / session",
+    value: "16",
+    trend: "+4 vs. last week",
+  },
+  {
+    label: "Assignments completed",
+    value: "5",
+    trend: "2 in review",
+  },
+  {
+    label: "Questions raised",
+    value: "3",
+    trend: "Reply to keep momentum",
+  },
+];
+
+export default function PracticePage() {
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title="Practice log"
+        description="Guided session summaries update automatically from the student practice experience."
+        actions={
+          <button
+            type="button"
+            className="rounded-xl border border-brand-dark px-4 py-2 text-sm font-medium text-brand-dark transition hover:bg-brand-light"
+          >
+            Export CSV
+          </button>
+        }
+      />
+
+      <section className="grid gap-4 md:grid-cols-3">
+        {practiceInsights.map((insight) => (
+          <article key={insight.label} className="space-y-1 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+            <p className="text-sm text-slate-500">{insight.label}</p>
+            <p className="text-3xl font-semibold text-slate-900">{insight.value}</p>
+            <p className="text-xs uppercase tracking-wide text-brand-dark">{insight.trend}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="mb-4 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <h2 className="text-lg font-semibold text-slate-900">Recent guided sessions</h2>
+          <div className="flex flex-wrap gap-2 text-sm">
+            <button className="rounded-xl border border-brand-dark px-3 py-2 text-brand-dark transition hover:bg-brand-light" type="button">
+              Filter by assignment
+            </button>
+            <button className="rounded-xl border border-brand-dark px-3 py-2 text-brand-dark transition hover:bg-brand-light" type="button">
+              Date range
+            </button>
+          </div>
+        </div>
+        <div className="grid gap-3">
+          {sessions.map((session) => (
+            <article key={`${session.student}-${session.assignment}`} className="flex flex-col gap-2 rounded-2xl border border-slate-100 bg-slate-50 p-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h3 className="text-base font-semibold text-slate-900">{session.assignment}</h3>
+                <p className="text-sm text-slate-600">{session.student}</p>
+              </div>
+              <div className="flex flex-col items-start gap-2 text-sm text-slate-600 md:flex-row md:items-center">
+                <span>{session.duration}</span>
+                <span>{session.completedAt}</span>
+                <button className="rounded-xl bg-brand-dark px-3 py-2 text-sm font-medium text-white transition hover:bg-brand" type="button">
+                  View summary
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(teacher)/teacher/questions/page.tsx
+++ b/src/app/(teacher)/teacher/questions/page.tsx
@@ -1,0 +1,77 @@
+import { PageHeader } from "@/components/page-header";
+
+const questions = [
+  {
+    student: "Alex Rivera",
+    question: "Can we review alternate fingerings for the top F?",
+    submitted: "1 hour ago",
+    assignment: "Concert G Major scale",
+  },
+  {
+    student: "Maya Chen",
+    question: "What tempo should I use when practicing with the metronome?",
+    submitted: "Yesterday",
+    assignment: "Chromatic warmup",
+  },
+  {
+    student: "Jordan Smith",
+    question: "Is it okay to record the tuner feedback to compare takes?",
+    submitted: "2 days ago",
+    assignment: "Long-tone breath builder",
+  },
+];
+
+export default function QuestionsPage() {
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title="Student questions"
+        description="Respond quickly to keep students motivated between lessons."
+        actions={
+          <button
+            type="button"
+            className="rounded-xl border border-brand-dark px-4 py-2 text-sm font-medium text-brand-dark transition hover:bg-brand-light"
+          >
+            Mark all as read
+          </button>
+        }
+      />
+
+      <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="mb-4 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <h2 className="text-lg font-semibold text-slate-900">Inbox</h2>
+          <div className="flex flex-wrap gap-2 text-sm">
+            <button className="rounded-xl border border-brand-dark px-3 py-2 text-brand-dark transition hover:bg-brand-light" type="button">
+              Filter by assignment
+            </button>
+            <button className="rounded-xl border border-brand-dark px-3 py-2 text-brand-dark transition hover:bg-brand-light" type="button">
+              Show resolved
+            </button>
+          </div>
+        </div>
+        <div className="grid gap-4">
+          {questions.map((item) => (
+            <article key={item.question} className="space-y-3 rounded-2xl border border-slate-100 bg-slate-50 p-4">
+              <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                <div>
+                  <h3 className="text-base font-semibold text-slate-900">{item.student}</h3>
+                  <p className="text-sm text-slate-600">{item.assignment}</p>
+                </div>
+                <span className="text-sm text-slate-500">{item.submitted}</span>
+              </div>
+              <p className="text-sm text-slate-700">{item.question}</p>
+              <div className="flex flex-wrap gap-2">
+                <button className="rounded-xl bg-brand-dark px-3 py-2 text-sm font-medium text-white transition hover:bg-brand" type="button">
+                  Reply
+                </button>
+                <button className="rounded-xl border border-brand-dark px-3 py-2 text-sm font-medium text-brand-dark transition hover:bg-brand-light" type="button">
+                  Archive
+                </button>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(teacher)/teacher/settings/page.tsx
+++ b/src/app/(teacher)/teacher/settings/page.tsx
@@ -1,0 +1,119 @@
+import { PageHeader } from "@/components/page-header";
+
+export default function SettingsPage() {
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title="Studio settings"
+        description="Update your teaching profile, notification preferences, and tuner defaults."
+      />
+
+      <section className="grid gap-6 lg:grid-cols-2">
+        <form className="space-y-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h2 className="text-lg font-semibold text-slate-900">Profile</h2>
+          <label className="flex flex-col gap-2 text-sm text-slate-600">
+            Display name
+            <input
+              className="rounded-xl border border-slate-200 px-3 py-2 text-slate-900 focus:border-brand-dark focus:outline-none focus:ring-2 focus:ring-brand/40"
+              placeholder="Jamie Thompson"
+              type="text"
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm text-slate-600">
+            Studio timezone
+            <select className="rounded-xl border border-slate-200 px-3 py-2 text-slate-900 focus:border-brand-dark focus:outline-none focus:ring-2 focus:ring-brand/40">
+              <option>America/New_York</option>
+              <option>America/Chicago</option>
+              <option>America/Denver</option>
+              <option>America/Los_Angeles</option>
+            </select>
+          </label>
+          <label className="flex flex-col gap-2 text-sm text-slate-600">
+            Primary instrument focus
+            <input
+              className="rounded-xl border border-slate-200 px-3 py-2 text-slate-900 focus:border-brand-dark focus:outline-none focus:ring-2 focus:ring-brand/40"
+              defaultValue="Alto saxophone"
+              type="text"
+            />
+          </label>
+          <button
+            type="button"
+            className="rounded-xl bg-brand-dark px-4 py-2 text-sm font-medium text-white transition hover:bg-brand"
+          >
+            Save profile
+          </button>
+        </form>
+
+        <form className="space-y-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h2 className="text-lg font-semibold text-slate-900">Notifications</h2>
+          <fieldset className="space-y-3 text-sm text-slate-600">
+            <label className="flex items-center gap-2">
+              <input defaultChecked type="checkbox" className="h-4 w-4 rounded border-slate-300 text-brand-dark focus:ring-brand" />
+              Lesson reminders
+            </label>
+            <label className="flex items-center gap-2">
+              <input defaultChecked type="checkbox" className="h-4 w-4 rounded border-slate-300 text-brand-dark focus:ring-brand" />
+              Practice summaries
+            </label>
+            <label className="flex items-center gap-2">
+              <input type="checkbox" className="h-4 w-4 rounded border-slate-300 text-brand-dark focus:ring-brand" />
+              Student questions
+            </label>
+          </fieldset>
+          <div className="space-y-2 text-sm text-slate-600">
+            <label className="flex items-center gap-2">
+              <input defaultChecked type="radio" name="contact" className="h-4 w-4 border-slate-300 text-brand-dark focus:ring-brand" />
+              Email
+            </label>
+            <label className="flex items-center gap-2">
+              <input type="radio" name="contact" className="h-4 w-4 border-slate-300 text-brand-dark focus:ring-brand" />
+              SMS (coming soon)
+            </label>
+          </div>
+          <button
+            type="button"
+            className="rounded-xl bg-brand-dark px-4 py-2 text-sm font-medium text-white transition hover:bg-brand"
+          >
+            Save notifications
+          </button>
+        </form>
+      </section>
+
+      <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-900">Tuner defaults</h2>
+        <div className="mt-4 grid gap-4 md:grid-cols-3">
+          <label className="flex flex-col gap-2 text-sm text-slate-600">
+            Instrument transposition
+            <select className="rounded-xl border border-slate-200 px-3 py-2 text-slate-900 focus:border-brand-dark focus:outline-none focus:ring-2 focus:ring-brand/40">
+              <option>Alto (E♭)</option>
+              <option>Tenor (B♭)</option>
+              <option>Bari (E♭)</option>
+            </select>
+          </label>
+          <label className="flex flex-col gap-2 text-sm text-slate-600">
+            Pitch tolerance (cents)
+            <input
+              className="rounded-xl border border-slate-200 px-3 py-2 text-slate-900 focus:border-brand-dark focus:outline-none focus:ring-2 focus:ring-brand/40"
+              defaultValue="10"
+              type="number"
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-sm text-slate-600">
+            Metronome default tempo
+            <input
+              className="rounded-xl border border-slate-200 px-3 py-2 text-slate-900 focus:border-brand-dark focus:outline-none focus:ring-2 focus:ring-brand/40"
+              defaultValue="80"
+              type="number"
+            />
+          </label>
+        </div>
+        <button
+          type="button"
+          className="mt-6 rounded-xl bg-brand-dark px-4 py-2 text-sm font-medium text-white transition hover:bg-brand"
+        >
+          Save tuner settings
+        </button>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(teacher)/teacher/students/[id]/page.tsx
+++ b/src/app/(teacher)/teacher/students/[id]/page.tsx
@@ -1,0 +1,100 @@
+import { notFound } from "next/navigation";
+
+import { PageHeader } from "@/components/page-header";
+
+const mockStudents = {
+  "1": {
+    name: "Alex Rivera",
+    level: "Intermediate",
+    goals: ["Strengthen tone across the break", "Expand scale fluency to three sharps"],
+  },
+  "2": {
+    name: "Maya Chen",
+    level: "Beginner",
+    goals: ["Solidify first five notes", "Introduce articulation patterns"],
+  },
+  "3": {
+    name: "Jordan Smith",
+    level: "Advanced",
+    goals: ["Develop altissimo flexibility", "Prepare for juries"],
+  },
+} satisfies Record<string, { name: string; level: string; goals: string[] }>;
+
+type StudentProfilePageProps = {
+  params: {
+    id: string;
+  };
+};
+
+export default function StudentProfilePage({ params }: StudentProfilePageProps) {
+  const student = mockStudents[params.id];
+
+  if (!student) {
+    notFound();
+  }
+
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title={student.name}
+        description={`${student.level} saxophonist · personalize assignments below.`}
+        actions={
+          <button
+            type="button"
+            className="rounded-xl bg-brand-dark px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-brand"
+          >
+            Add assignment
+          </button>
+        }
+      />
+
+      <section className="grid gap-6 lg:grid-cols-2">
+        <article className="space-y-3 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h2 className="text-lg font-semibold text-slate-900">Lesson log</h2>
+          <ul className="space-y-2 text-sm text-slate-600">
+            <li>Last lesson: Reviewed Concert G major scale, focused on long-tone breath support.</li>
+            <li>Homework: 10-minute chromatic warmup, 3x scale reps with tuner guidance.</li>
+          </ul>
+        </article>
+
+        <article className="space-y-3 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h2 className="text-lg font-semibold text-slate-900">Goals</h2>
+          <ul className="space-y-2 text-sm text-slate-600">
+            {student.goals.map((goal) => (
+              <li key={goal} className="flex items-start gap-2">
+                <span className="mt-1 inline-flex h-2 w-2 rounded-full bg-brand-dark" aria-hidden />
+                <span>{goal}</span>
+              </li>
+            ))}
+          </ul>
+          <button
+            type="button"
+            className="inline-flex items-center justify-center rounded-xl border border-brand-dark px-3 py-2 text-sm font-medium text-brand-dark transition hover:bg-brand-light"
+          >
+            Update goals
+          </button>
+        </article>
+      </section>
+
+      <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-900">Recent practice sessions</h2>
+        <div className="mt-4 grid gap-3 text-sm text-slate-600">
+          <div className="flex flex-col gap-2 rounded-2xl border border-slate-100 bg-slate-50 p-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="font-semibold text-slate-900">Guided session · Concert G Major</p>
+              <p>Time spent: 18 minutes</p>
+            </div>
+            <span>Completed yesterday · Notes: "Need help with second octave"</span>
+          </div>
+          <div className="flex flex-col gap-2 rounded-2xl border border-slate-100 bg-slate-50 p-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <p className="font-semibold text-slate-900">Metronome drill · Quarter = 80</p>
+              <p>Time spent: 12 minutes</p>
+            </div>
+            <span>Completed 3 days ago · Notes: "Struggled with crossing break"</span>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/(teacher)/teacher/students/page.tsx
+++ b/src/app/(teacher)/teacher/students/page.tsx
@@ -1,0 +1,79 @@
+import Link from "next/link";
+
+import { PageHeader } from "@/components/page-header";
+
+const students = [
+  {
+    id: "1",
+    name: "Alex Rivera",
+    level: "Intermediate",
+    focus: "Tone and intonation",
+    nextLesson: "Tue, 4:30 PM",
+  },
+  {
+    id: "2",
+    name: "Maya Chen",
+    level: "Beginner",
+    focus: "First octave finger transitions",
+    nextLesson: "Wed, 5:15 PM",
+  },
+  {
+    id: "3",
+    name: "Jordan Smith",
+    level: "Advanced",
+    focus: "Altissimo warmups",
+    nextLesson: "Thu, 6:00 PM",
+  },
+];
+
+export default function StudentsPage() {
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title="Students"
+        description="Keep roster details current to tailor assignments and track lesson history."
+        actions={
+          <button className="rounded-xl bg-brand-dark px-4 py-2 text-sm font-medium text-white shadow-sm transition hover:bg-brand" type="button">
+            Add new student
+          </button>
+        }
+      />
+
+      <section className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="mb-4 flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <p className="text-sm text-slate-600">
+            Track lesson notes, assignments, and practice expectations for each player.
+          </p>
+          <button type="button" className="rounded-xl border border-brand-dark px-4 py-2 text-sm font-medium text-brand-dark transition hover:bg-brand-light">
+            Import roster
+          </button>
+        </div>
+
+        <div className="grid gap-4">
+          {students.map((student) => (
+            <article
+              key={student.id}
+              className="flex flex-col gap-3 rounded-2xl border border-slate-100 bg-slate-50 p-4 md:flex-row md:items-center md:justify-between"
+            >
+              <div>
+                <h2 className="text-base font-semibold text-slate-900">{student.name}</h2>
+                <p className="text-sm text-slate-600">
+                  {student.level} · Focus: {student.focus}
+                </p>
+              </div>
+              <div className="flex flex-col items-start gap-2 text-sm text-slate-500 md:flex-row md:items-center">
+                <span>Next lesson: {student.nextLesson}</span>
+                <Link
+                  href={`/teacher/students/${student.id}`}
+                  className="inline-flex items-center rounded-xl bg-white px-3 py-2 text-sm font-medium text-brand-dark shadow-sm transition hover:bg-brand-light"
+                >
+                  Open profile
+                </Link>
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/docs/design/page.tsx
+++ b/src/app/docs/design/page.tsx
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Metadata } from "next";
+
+function getDesignDoc() {
+  const docPath = join(process.cwd(), "docs", "design.md");
+  try {
+    return readFileSync(docPath, "utf8");
+  } catch (error) {
+    console.error("Unable to load design document", error);
+    return "Design document could not be loaded.";
+  }
+}
+
+export const metadata: Metadata = {
+  title: "Design Document | Chops Buddy",
+  description: "Detailed MVP design documentation for the Chops Buddy platform.",
+};
+
+export default function DesignPage() {
+  const markdown = getDesignDoc();
+
+  return (
+    <main className="mx-auto flex max-w-5xl flex-col gap-8 px-6 py-16">
+      <header className="space-y-3 text-center">
+        <p className="text-sm font-semibold uppercase tracking-[0.2em] text-brand-dark">
+          Documentation
+        </p>
+        <h1 className="text-4xl font-semibold text-slate-900">Chops Buddy MVP Design</h1>
+        <p className="text-base text-slate-600">
+          This document outlines goals, architecture, page flows, and rollout plans for the initial
+          release.
+        </p>
+      </header>
+
+      <article className="rounded-3xl bg-white p-6 shadow-lg ring-1 ring-brand-light">
+        <pre className="whitespace-pre-wrap text-sm leading-relaxed text-slate-700">
+          {markdown}
+        </pre>
+      </article>
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  @apply bg-white text-slate-900 antialiased;
+}
+
+a {
+  @apply text-brand-dark underline-offset-4 transition hover:underline;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import type { ReactNode } from "react";
+import "./globals.css";
+
+const inter = Inter({ subsets: ["latin"], display: "swap" });
+
+export const metadata: Metadata = {
+  title: "Chops Buddy",
+  description: "Guided saxophone practice and studio management platform.",
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: ReactNode;
+}>) {
+  return (
+    <html lang="en" className="h-full bg-brand-light">
+      <body className={`${inter.className} min-h-screen bg-white text-slate-900`}>
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,90 @@
+import Link from "next/link";
+
+const features = [
+  {
+    title: "Teacher Studio Hub",
+    description:
+      "Manage students, lessons, and assignments from a single, saxophone-focused dashboard.",
+  },
+  {
+    title: "Guided Practice Sessions",
+    description:
+      "Auto-generated routines with tuner feedback help students build reliable chops between lessons.",
+  },
+  {
+    title: "Practice Insights",
+    description:
+      "Review minutes practiced and session reflections to tailor upcoming lessons.",
+  },
+];
+
+export default function Home() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-16 px-6 py-16">
+      <section className="flex flex-col gap-6 text-center">
+        <span className="mx-auto inline-flex items-center gap-2 rounded-full bg-brand-light px-4 py-1 text-sm font-semibold text-brand-dark">
+          MVP in progress
+        </span>
+        <h1 className="text-4xl font-semibold tracking-tight text-slate-900 md:text-6xl">
+          Coach better saxophone practice with Chops Buddy.
+        </h1>
+        <p className="mx-auto max-w-2xl text-lg text-slate-600">
+          A teaching companion that transforms lesson assignments into guided practice plans,
+          tracks time-on-task, and keeps teacher-student communication organized.
+        </p>
+        <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
+          <Link
+            href="#teacher-actions"
+            className="inline-flex items-center justify-center rounded-full bg-brand-dark px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-brand"
+          >
+            Explore the MVP scope
+          </Link>
+          <Link
+            href="/docs/design"
+            className="inline-flex items-center justify-center rounded-full border border-brand-dark px-6 py-3 text-base font-semibold text-brand-dark transition hover:bg-brand-light"
+          >
+            Read the design document
+          </Link>
+          <Link
+            href="/teacher/dashboard"
+            className="inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-slate-700"
+          >
+            View teacher workspace
+          </Link>
+        </div>
+      </section>
+
+      <section
+        id="teacher-actions"
+        className="grid grid-cols-1 gap-8 rounded-3xl bg-white p-8 shadow-lg ring-1 ring-brand-light md:grid-cols-3"
+      >
+        {features.map((feature) => (
+          <article key={feature.title} className="flex flex-col gap-3 text-left">
+            <h2 className="text-xl font-semibold text-brand-dark">{feature.title}</h2>
+            <p className="text-base text-slate-600">{feature.description}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="grid gap-10 rounded-3xl bg-slate-900 p-10 text-white md:grid-cols-2">
+        <div className="space-y-4">
+          <h2 className="text-3xl font-semibold">Why start with saxophone?</h2>
+          <p className="text-base text-slate-200">
+            Chops Buddy focuses on saxophonists first, allowing us to dial in tuner thresholds,
+            repertoire, and pedagogy that matches the needs of single-reed players. The platform
+            is built on Next.js and Supabase for rapid iteration and robust data security.
+          </p>
+        </div>
+        <div className="space-y-3 rounded-2xl bg-slate-800 p-6">
+          <h3 className="text-xl font-semibold">MVP milestones</h3>
+          <ul className="space-y-2 text-sm text-slate-200">
+            <li>• Teacher onboarding, student roster, and availability scheduling</li>
+            <li>• Scale assignment composer feeding guided practice steps</li>
+            <li>• Web-based tuner with pitch detection tuned for saxophone</li>
+            <li>• Practice session summaries with minutes practiced and student questions</li>
+          </ul>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from "react";
+
+import { NavLink } from "@/components/nav-link";
+
+export type AppNavItem = {
+  href: string;
+  label: string;
+  description?: string;
+};
+
+type AppShellProps = {
+  children: ReactNode;
+  navItems: AppNavItem[];
+  header?: ReactNode;
+  footer?: ReactNode;
+};
+
+export function AppShell({ children, navItems, header, footer }: AppShellProps) {
+  return (
+    <div className="flex min-h-screen flex-col bg-slate-50">
+      <header className="border-b border-slate-200 bg-white">
+        <div className="mx-auto flex max-w-6xl items-center justify-between gap-4 px-6 py-4">
+          <div className="flex flex-col">
+            <span className="text-sm font-semibold uppercase tracking-wide text-brand-dark">
+              Chops Buddy
+            </span>
+            <span className="text-base text-slate-500">Teacher workspace</span>
+          </div>
+          {header}
+        </div>
+      </header>
+
+      <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col gap-8 px-6 py-10 lg:flex-row">
+        <aside className="lg:w-64">
+          <nav className="flex flex-row gap-3 overflow-x-auto rounded-2xl border border-slate-200 bg-white p-3 lg:flex-col lg:gap-2">
+            {navItems.map((item) => (
+              <div key={item.href} className="min-w-[10rem]">
+                <NavLink href={item.href} label={item.label} />
+                {item.description ? (
+                  <p className="mt-2 hidden text-xs text-slate-500 lg:block">{item.description}</p>
+                ) : null}
+              </div>
+            ))}
+          </nav>
+        </aside>
+
+        <main className="flex-1 space-y-8">
+          {children}
+          {footer ? <div className="border-t border-slate-200 pt-6 text-sm text-slate-500">{footer}</div> : null}
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/components/nav-link.tsx
+++ b/src/components/nav-link.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { cn } from "@/lib/utils";
+
+type NavLinkProps = {
+  href: string;
+  label: string;
+};
+
+export function NavLink({ href, label }: NavLinkProps) {
+  const pathname = usePathname();
+  const isActive = pathname === href || pathname.startsWith(`${href}/`);
+
+  return (
+    <Link
+      href={href}
+      className={cn(
+        "flex items-center justify-between gap-2 rounded-xl px-4 py-2 text-sm font-medium transition",
+        isActive
+          ? "bg-brand-dark text-white shadow-sm"
+          : "text-slate-600 hover:bg-brand-light hover:text-brand-dark"
+      )}
+    >
+      <span>{label}</span>
+      {isActive ? <span className="text-xs uppercase tracking-wide">Now</span> : null}
+    </Link>
+  );
+}

--- a/src/components/page-header.tsx
+++ b/src/components/page-header.tsx
@@ -1,0 +1,19 @@
+import type { ReactNode } from "react";
+
+type PageHeaderProps = {
+  title: string;
+  description?: string;
+  actions?: ReactNode;
+};
+
+export function PageHeader({ title, description, actions }: PageHeaderProps) {
+  return (
+    <div className="flex flex-col gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm lg:flex-row lg:items-center lg:justify-between">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-semibold text-slate-900">{title}</h1>
+        {description ? <p className="text-sm text-slate-600">{description}</p> : null}
+      </div>
+      {actions ? <div className="flex flex-wrap items-center gap-3">{actions}</div> : null}
+    </div>
+  );
+}

--- a/src/lib/supabase-client.ts
+++ b/src/lib/supabase-client.ts
@@ -1,0 +1,14 @@
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  console.warn(
+    "Supabase environment variables are missing. API calls will fail until NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY are configured.",
+  );
+}
+
+export const supabase = supabaseUrl && supabaseAnonKey
+  ? createClient(supabaseUrl, supabaseAnonKey)
+  : undefined;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,5 @@
+export function cn(
+  ...classes: Array<string | undefined | null | false>
+): string {
+  return classes.filter(Boolean).join(" ");
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,19 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./src/**/*.{js,ts,jsx,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          DEFAULT: "#3C6E71",
+          dark: "#284B63",
+          light: "#D9D9D9",
+        },
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a reusable teacher workspace shell with navigation components
- add placeholder dashboard, student management, assignment, practice, question, and settings pages
- link the marketing page and README to the new teacher workspace prototype

## Testing
- npm install *(fails: 403 Forbidden fetching @supabase/supabase-js)*

------
https://chatgpt.com/codex/tasks/task_e_68e4c15ae30883228fb2fb5967af85ca